### PR TITLE
Add support for deleting RBACDefinitions

### DIFF
--- a/manage_rbac.py
+++ b/manage_rbac.py
@@ -69,6 +69,12 @@ class RBACManager(object):
                     logging.info("Handling %s on %s" % (operation, name))
                     self._update(yaml.load(obj['data']['rbac']))
                     resource_version = new_resource_version
+                elif operation in ['DELETED']:
+                    metadata = obj.get("metadata")
+                    name = metadata['name']
+                    logging.info("Handling %s on %s" % (operation, name))
+                    self._update([])
+                    resource_version = ''
 
     def _update(self, rbac_users):
         """ Update rbac users from a list """


### PR DESCRIPTION
Fixes #8 

Since the current support is only for 1 RBACDefinition, any delete event means delete everything we're managing.