### PR TITLE
Add support for managing ServiceAccounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RBAC Manager
 
-RBAC Manager simplifies the management of role bindings in Kubernetes.
+RBAC Manager simplifies the management of RBAC resources in Kubernetes.
 
 ## Purpose
 
@@ -23,9 +23,20 @@ With RBAC Manager, we can represent the state described above in a single YAML f
       namespace: namespace-2
     - clusterRole: view
       namespace: namespace-3
+- user: ci_system
+  kind: ServiceAccount
+  clusterRoleBindings:
+    - clusterRole: cluster-admin
 ```
 
-Running RBAC Manager with the above configuration will create all these requested role bindings for you. Importantly, it will compare the requested state with the existing state and only make changes necessary to reach the requested state. It uses Kubernetes labels to track which role bindings it manages. Any role bindings with that label that are not described in the configuration it is using will be removed, and any role bindings described in that configuration that do not exist will be added.
+Running RBAC Manager with the above configuration will:
+
+* Ensure the `ci_system` `ServiceAccount` exists
+* Create 2 `RoleBinding`s for the `User` a@example.com
+* Create 3 `RoleBinding`s for the `User` b@example.com
+* Create 1 `ClusterRoleBinding` for the `ServiceAccount` ci_system
+
+Importantly, it will compare the requested state with the existing state and only make changes necessary to reach the requested state. It uses Kubernetes labels to track which resources it manages. Any `ServiceAccount`, `RoleBinding`, or `ClusterRoleBinding` with that label that are not described in the configuration will be removed, and any resources described in that configuration that do not exist will be added.
 
 ## Usage
 

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -33,6 +33,12 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - "" # core
+    resources:
+      - serviceaccounts
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/examples/generate_config.sh
+++ b/examples/generate_config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script is useful when managing service accounts
+# Run ./generate_config.sh default my-service-account
+# to get a valid KUBECONFIG file for kubectl to auth as the
+# specified service account
+
+set -eo pipefail
+
+kc() {
+  kubectl -n "${namespace}" $@
+}
+
+namespace="$1"
+serviceaccount="$2"
+
+sa_secret_name=$(kc get serviceaccount "${serviceaccount}" -o 'jsonpath={.secrets[0].name}')
+
+context_name="$(kubectl config current-context)"
+cluster_name="$(kubectl config view -o "jsonpath={.contexts[?(@.name==\"${context_name}\")].context.cluster}")"
+server_name="$(kubectl config view -o "jsonpath={.clusters[?(@.name==\"${cluster_name}\")].cluster.server}")"
+cacert="$(kc get secret "${sa_secret_name}" -o "jsonpath={.data.ca\.crt}" | base64 --decode)"
+token="$(kubectl get secret "${sa_secret_name}" -o "jsonpath={.data.token}" | base64 --decode)"
+
+export KUBECONFIG="$(mktemp)"
+kubectl config set-credentials "${serviceaccount}" --token="${token}" >/dev/null
+ca_crt="$(mktemp)"; echo "${cacert}" > ${ca_crt}
+kubectl config set-cluster "${cluster_name}" --server="${server_name}" --certificate-authority="$ca_crt" --embed-certs >/dev/null
+kubectl config set-context "${cluster_name}" --cluster="${cluster_name}" --user="${serviceaccount}" >/dev/null
+kubectl config use-context "${cluster_name}" >/dev/null
+
+KUBECONFIG_DATA=$(cat "${KUBECONFIG}")
+rm ${KUBECONFIG}
+echo "${KUBECONFIG_DATA}"

--- a/manage_rbac.py
+++ b/manage_rbac.py
@@ -113,6 +113,9 @@ class RBACManager(object):
 
             if user_kind == 'ServiceAccount':
                 sa_namespace = rbac_user.get('namespace', self._namespace)
+                subject = kubernetes.client.V1Subject(
+                    kind=user_kind, name=escaped_user_name,
+                    namespace=sa_namespace)
                 metadata = kubernetes.client.V1ObjectMeta(
                     name=escaped_user_name, labels=labels, namespace=sa_namespace)
                 service_account = kubernetes.client.V1ServiceAccount(


### PR DESCRIPTION
Fixes #7 
Depends on #8 

Managing `ServiceAccount`s works just like the other resources. Any user that doesn't have a `kind` specified is assumed to be an external user. If `kind` is set to `ServiceAccount` we manage it just like `RoleBinding`s and `ClusterRoleBindings`: create account if it doesn't exist (with labels), delete any accounts with labels that exist but aren't in the spec.

`ServiceAccount`s are created in the same namespace as rbac-manager by default, but that be overridden on a case by case basis too.