### PR TITLE
Cleaning Up CRD + CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: 
+      - run:
           name: build tag and push
           command: |
             tag=$(echo ${CIRCLE_BRANCH} | sed "s/\//\-/g")
             docker login quay.io -u="reactiveops+circleci"  -p="${quay_token}"
             docker build -t quay.io/reactiveops/rbac-manager:${tag} .
             docker tag quay.io/reactiveops/rbac-manager:${tag} quay.io/reactiveops/rbac-manager:${CIRCLE_SHA1}
-            docker push quay.io/reactiveops/rbac-manager:${tag} 
+            docker push quay.io/reactiveops/rbac-manager:${tag}
             docker push quay.io/reactiveops/rbac-manager:${CIRCLE_SHA1}
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,62 @@
 version: 2
 
-jobs:
-  build_and_push:
-    docker:
-      - image: quay.io/reactiveops/ci-images:v7.2.8-alpine
+references:
+  docker_build_and_push: &docker_build_and_push
+    run:
+      name: Docker login, build, and push
+      command: |
+        docker login quay.io -u="reactiveops+circleci" -p="${quay_token}"
+        docker build -f Dockerfile -t quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG .
+        docker build -f Dockerfile.ci -t quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG-ci .
+        docker push quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG
+        docker push quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG-ci
 
+  github_release: &github_release
+    run:
+      name: GitHub release
+      command: |
+        git fetch --tags
+        curl -O https://raw.githubusercontent.com/reactiveops/release.sh/v0.0.2/release
+        /bin/bash release
+
+jobs:
+  build:
+    docker:
+      - image: circleci/buildpack-deps:jessie
     steps:
       - checkout
       - setup_remote_docker
-      - run:
-          name: build tag and push
-          command: |
-            tag=$(echo ${CIRCLE_BRANCH} | sed "s/\//\-/g")
-            docker login quay.io -u="reactiveops+circleci"  -p="${quay_token}"
-            docker build -t quay.io/reactiveops/rbac-manager:${tag} .
-            docker tag quay.io/reactiveops/rbac-manager:${tag} quay.io/reactiveops/rbac-manager:${CIRCLE_SHA1}
-            docker push quay.io/reactiveops/rbac-manager:${tag}
-            docker push quay.io/reactiveops/rbac-manager:${CIRCLE_SHA1}
+      - run: echo 'export DOCKER_BASE_TAG=dev-$CIRCLE_SHA1' >> $BASH_ENV
+      - *docker_build_and_push
+
+  release:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: echo 'export GITHUB_ORGANIZATION=$CIRCLE_PROJECT_USERNAME' >> $BASH_ENV
+      - run: echo 'export GITHUB_REPOSITORY=$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
+      - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
+      - *github_release
+      - *docker_build_and_push
+
 
 workflows:
   version: 2
-  build_test:
+  build:
     jobs:
-      - build_and_push:
+      - build:
           context: org-global
+          filters:
+            tags:
+              only: /^testing-.*/
+  release:
+    jobs:
+      - release:
+          context: org-global
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              ignore: /^testing-.*/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Importantly, it will compare the requested state with the existing state and onl
 
 ## Usage
 
-At it's core, this is a Python script that runs with YAML configuration. There are many ways to use this, we'll cover 3 of them here:
+At it's core, this is a Python script that runs with YAML configuration. There are many ways to use this, we'll cover 4 of them here:
 
 ### As a Python Script
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ kubectl delete namespace rbac-manager
 
 ### As a Kubernetes Controller
 
-RBAC Manager can also be run as a controler using custom resources to store this format of RBAC configuration. These custom resources are `rbacdefinitions`. The RBAC Manager controller listens for `rbacdefinition` updates, and will automatically make the requested changes when a `rbacdefinition` is created or updated.
+RBAC Manager can also be run as a controler using custom resources to store this format of RBAC configuration. These custom resources are `RBACDefinitions`. The RBAC Manager controller listens for `RBACDefinitions` updates, and will automatically make the requested changes when a `rbacdefinition` is created or updated.
 
 You can deploy the controller using helm:
 
@@ -88,22 +88,21 @@ Then you can make changes by configuring an `RBACDefinition` in the same namespa
 
 ```
 ---
-apiVersion: rbacmanager.k8s.io/v1
+apiVersion: rbac-manager.reactiveops.io/v1beta1
 kind: RBACDefinition
 metadata:
   name: rbac-manager-config
   namespace: rbac-manager
-data:
-  rbac: |-
-    - user: one@example.com
-      clusterRoleBindings:
-        - clusterRole: cluster-admin
-    - user: two@example.com
-      clusterRoleBindings:
-        - clusterRole: edit
-      roleBindings:
-        - clusterRole: cluster-admin
-          namespace: default
+rbacUsers:
+  - user: one@example.com
+    clusterRoleBindings:
+      - clusterRole: cluster-admin
+  - user: two@example.com
+    clusterRoleBindings:
+      - clusterRole: edit
+    roleBindings:
+      - clusterRole: cluster-admin
+        namespace: default
 ```
 
 ### As part of a CI Workflow

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -30,7 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-{{ toYaml .Values.resources | indent 8 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -19,7 +19,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups:
-      - rbacmanager.k8s.io
+      - rbac-manager.reactiveops.io
     resources:
       - rbacdefinitions
     verbs:

--- a/chart/templates/rbacdefinition-crd.yml
+++ b/chart/templates/rbacdefinition-crd.yml
@@ -2,14 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: rbacdefinitions.rbacmanager.k8s.io
+  name: rbacdefinitions.rbac-manager.reactiveops.io
   labels:
     app: {{ template "rbac-manager.name" . }}
     chart: {{ template "rbac-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  group: rbacmanager.k8s.io
+  group: rbac-manager.reactiveops.io
   version: v1
   scope: Namespaced
   names:
@@ -18,4 +18,3 @@ spec:
     kind: RBACDefinition
     shortNames:
       - rbacdef
-      - rd

--- a/chart/templates/rbacdefinition-crd.yml
+++ b/chart/templates/rbacdefinition-crd.yml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   group: rbac-manager.reactiveops.io
-  version: v1
+  version: v1beta1
   scope: Namespaced
   names:
     plural: rbacdefinitions

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,9 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 

--- a/examples/k8s/all.yml
+++ b/examples/k8s/all.yml
@@ -77,7 +77,7 @@ metadata:
     heritage: Tiller
 spec:
   group: rbac-manager.reactiveops.io
-  version: v1
+  version: v1beta1
   scope: Namespaced
   names:
     plural: rbacdefinitions

--- a/examples/k8s/all.yml
+++ b/examples/k8s/all.yml
@@ -85,7 +85,6 @@ spec:
     kind: RBACDefinition
     shortNames:
       - rbacdef
-      - rd
 
 ---
 # Source: rbac-manager/templates/controller.yaml

--- a/examples/k8s/all.yml
+++ b/examples/k8s/all.yml
@@ -13,29 +13,6 @@ metadata:
     release: rops
     heritage: Tiller
 ---
-# Source: rbac-manager/templates/rbacdefinition-crd.yml
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: rbacdefinitions.rbacmanager.k8s.io
-  labels:
-    app: rbac-manager
-    chart: rbac-manager-0.1.0
-    release: rops
-    heritage: Tiller
-spec:
-  group: rbacmanager.k8s.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: rbacdefinitions
-    singular: rbacdefinition
-    kind: RBACDefinition
-    shortNames:
-      - rbacdef
-      - rd
----
-# Source: rbac-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -47,7 +24,7 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups:
-      - rbacmanager.k8s.io
+      - rbac-manager.reactiveops.io
     resources:
       - rbacdefinitions
     verbs:
@@ -61,8 +38,13 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - "" # core
+    resources:
+      - serviceaccounts
+    verbs:
+      - '*'
 ---
-# Source: rbac-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -79,9 +61,35 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rops-rbac-manager
-    namespace: "rbac-manager"
+    namespace: "default"
+
+---
+# Source: rbac-manager/templates/rbacdefinition-crd.yml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rbacdefinitions.rbac-manager.reactiveops.io
+  labels:
+    app: rbac-manager
+    chart: rbac-manager-0.1.0
+    release: rops
+    heritage: Tiller
+spec:
+  group: rbac-manager.reactiveops.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: rbacdefinitions
+    singular: rbacdefinition
+    kind: RBACDefinition
+    shortNames:
+      - rbacdef
+      - rd
+
 ---
 # Source: rbac-manager/templates/controller.yaml
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -113,6 +121,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        requests:
-          cpu: 100m
-          memory: 128Mi
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi


### PR DESCRIPTION
It looks like it's preferable to avoid using a `k8s.io` domain for CRDs and instead opt for a company specific one. In this case, I've chosen to use `reactiveops.io`. At the same time, I've updated the CRD to just have a `rbacUsers` list instead of referencing what was effectively a YAML string that needed to be parsed separately. 

On the CircleCI front, I've added support for the CI image as well as better support for Github releases (inspired by rok8s-scripts).