### PR TITLE
Updating helm chart to default to rbac-manager namespace, updating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,15 @@ kubectl delete namespace rbac-manager
 
 RBAC Manager can also be run as a controler using custom resources to store this format of RBAC configuration. These custom resources are `RBACDefinitions`. The RBAC Manager controller listens for `RBACDefinitions` updates, and will automatically make the requested changes when a `rbacdefinition` is created or updated.
 
-You can deploy the controller using helm:
+You can deploy the controller using helm. This will install all resources in a `rbac-manager` namespace by default. An example of the Kubernetes configuration Helm generates can be found in `examples/k8s/all.yml`.
 
 ```
-helm upgrade --install rbac-manager chart/ --namespace rbac-manager
+helm upgrade --install rbac-manager chart/
 ```
 
 Then you can make changes by configuring an `RBACDefinition` in the same namespace:
 
 ```
----
 apiVersion: rbac-manager.reactiveops.io/v1beta1
 kind: RBACDefinition
 metadata:

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "rbac-manager.fullname" . }}
+  namespace:  {{ .Values.namespace }}
   labels:
     app: {{ template "rbac-manager.name" . }}
     chart: {{ template "rbac-manager.chart" . }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "rbac-manager.fullname" . }}
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ template "rbac-manager.name" . }}
     chart: {{ template "rbac-manager.chart" . }}

--- a/chart/templates/rbacdefinition-crd.yml
+++ b/chart/templates/rbacdefinition-crd.yml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: rbacdefinitions.rbac-manager.reactiveops.io
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ template "rbac-manager.name" . }}
     chart: {{ template "rbac-manager.chart" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,8 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+namespace: rbac-manager
+
 nodeSelector: {}
 
 tolerations: []

--- a/examples/ci/.circleci/config.yml
+++ b/examples/ci/.circleci/config.yml
@@ -36,7 +36,7 @@ references:
 jobs:
   build:
     docker:
-      - image: quay.io/reactiveops/rbac-manager:0.1.4-ci
+      - image: quay.io/reactiveops/rbac-manager:0.3.0-ci
     steps:
       - checkout:
           path: /rbac-manager/ci

--- a/examples/k8s/all.yml
+++ b/examples/k8s/all.yml
@@ -6,21 +6,22 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rops-rbac-manager
+  name: rbac-manager
+  namespace: rbac-manager
   labels:
     app: rbac-manager
     chart: rbac-manager-0.1.0
-    release: rops
+    release: rbac-manager
     heritage: Tiller
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rops-rbac-manager
+  name: rbac-manager
   labels:
     app: rbac-manager
     chart: rbac-manager-0.1.0
-    release: rops
+    release: rbac-manager
     heritage: Tiller
 rules:
   - apiGroups:
@@ -48,20 +49,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: rops-rbac-manager
+  name: rbac-manager
   labels:
     app: rbac-manager
     chart: rbac-manager-0.1.0
-    release: rops
+    release: rbac-manager
     heritage: Tiller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rops-rbac-manager
+  name: rbac-manager
 subjects:
   - kind: ServiceAccount
-    name: rops-rbac-manager
-    namespace: "default"
+    name: rbac-manager
+    namespace: "rbac-manager"
 
 ---
 # Source: rbac-manager/templates/rbacdefinition-crd.yml
@@ -70,10 +71,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: rbacdefinitions.rbac-manager.reactiveops.io
+  namespace: rbac-manager
   labels:
     app: rbac-manager
     chart: rbac-manager-0.1.0
-    release: rops
+    release: rbac-manager
     heritage: Tiller
 spec:
   group: rbac-manager.reactiveops.io
@@ -92,25 +94,26 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: rops-rbac-manager
+  name: rbac-manager
+  namespace:  rbac-manager
   labels:
     app: rbac-manager
     chart: rbac-manager-0.1.0
-    release: rops
+    release: rbac-manager
     heritage: Tiller
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: rbac-manager
-      release: rops
+      release: rbac-manager
   template:
     metadata:
       labels:
         app: rbac-manager
-        release: rops
+        release: rbac-manager
     spec:
-      serviceAccountName: rops-rbac-manager
+      serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
         image: "quay.io/reactiveops/rbac-manager:0.3.0"

--- a/examples/k8s/job/03-job.yaml
+++ b/examples/k8s/job/03-job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: rbac-manager
       containers:
         - name: rbac-manager
-          image: quay.io/reactiveops/rbac-manager:latest
+          image: quay.io/reactiveops/rbac-manager:0.3.0
           command:
             - python
             - manage_rbac.py


### PR DESCRIPTION
I ran into some strange issues when I tried a Helm install without specifying a namespace. For now, I'm going to just set a reasonable default here in `values.yaml`. In my testing, Helm also created the namespace with this configuration, so it did not need to exist previously.