### PR TITLE
Removing Github release from CI, updating image references in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,6 @@ references:
         docker push quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG
         docker push quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG-ci
 
-  github_release: &github_release
-    run:
-      name: GitHub release
-      command: |
-        git fetch --tags
-        curl -O https://raw.githubusercontent.com/reactiveops/release.sh/v0.0.2/release
-        /bin/bash release
-
 jobs:
   build:
     docker:
@@ -35,10 +27,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: echo 'export GITHUB_ORGANIZATION=$CIRCLE_PROJECT_USERNAME' >> $BASH_ENV
-      - run: echo 'export GITHUB_REPOSITORY=$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
-      - *github_release
       - *docker_build_and_push
 
 

--- a/examples/ci/.circleci/config.yml
+++ b/examples/ci/.circleci/config.yml
@@ -36,7 +36,7 @@ references:
 jobs:
   build:
     docker:
-      - image: quay.io/reactiveops/rbac-manager:0.1.4-ci
+      - image: quay.io/reactiveops/rbac-manager:0.3.0-ci
     steps:
       - checkout:
           path: /rbac-manager/ci

--- a/examples/k8s/job/03-job.yaml
+++ b/examples/k8s/job/03-job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: rbac-manager
       containers:
         - name: rbac-manager
-          image: quay.io/reactiveops/rbac-manager:latest
+          image: quay.io/reactiveops/rbac-manager:0.3.0
           command:
             - python
             - manage_rbac.py


### PR DESCRIPTION
This is meant to be a temporary change until we can improve our build process.