### PR TITLE
Removing status from CRD validation for k8s 1.11

### DIFF
--- a/chart/templates/customresourcedefinition.yaml
+++ b/chart/templates/customresourcedefinition.yaml
@@ -66,8 +66,3 @@ spec:
       - rbacBindings
       type: object
   version: v1beta1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -127,11 +127,6 @@ spec:
       - rbacBindings
       type: object
   version: v1beta1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 
 ---
 # Source: rbac-manager/templates/controller.yaml


### PR DESCRIPTION
This `status` field was an unnecessary part of the CRD spec and broke deployments in Kubernetes 1.11. This should fix https://github.com/reactiveops/rbac-manager/issues/32.