### PR TITLE
Include matchexpressions when checking if namespace reconciler should run.

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -158,7 +158,7 @@ spec:
       serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
-        image: "quay.io/reactiveops/rbac-manager:0.6.0"
+        image: "quay.io/reactiveops/rbac-manager:0.6.1"
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1200

--- a/pkg/controller/rbacdefinition/parser.go
+++ b/pkg/controller/rbacdefinition/parser.go
@@ -177,8 +177,14 @@ func (p *Parser) parseRoleBinding(
 func (p *Parser) hasNamespaceSelectors(rbacDef *rbacmanagerv1beta1.RBACDefinition) bool {
 	for _, rbacBinding := range rbacDef.RBACBindings {
 		for _, roleBinding := range rbacBinding.RoleBindings {
-			if roleBinding.Namespace == "" && roleBinding.NamespaceSelector.MatchLabels != nil {
-				return true
+			if roleBinding.Namespace == "" {
+				// Split these up instead of using || so we can test both paths.
+				if roleBinding.NamespaceSelector.MatchLabels != nil {
+					return true
+				}
+				if roleBinding.NamespaceSelector.MatchExpressions != nil {
+					return true
+				}
 			}
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version represents the current version of RBAC Manager
-	Version = "0.6.0"
+	Version = "0.6.1"
 )


### PR DESCRIPTION
Fixes #48.  Adds tests to make sure we cover this in the future